### PR TITLE
Feat: LogOrders

### DIFF
--- a/api/models/orders.py
+++ b/api/models/orders.py
@@ -11,5 +11,4 @@ class Order(Base):
     customer_name = Column(String(100))
     order_date = Column(DATETIME, nullable=False, server_default=str(datetime.now()))
     description = Column(String(300))
-
     order_details = relationship("OrderDetail", back_populates="order")

--- a/api/routers/orders.py
+++ b/api/routers/orders.py
@@ -3,6 +3,8 @@ from sqlalchemy.orm import Session
 from ..controllers import orders as controller
 from ..schemas import orders as schema
 from ..dependencies.database import engine, get_db
+from fastapi import Query
+from datetime import datetime
 
 router = APIRouter(
     tags=['Orders'],
@@ -14,6 +16,17 @@ router = APIRouter(
 def create(request: schema.OrderCreate, db: Session = Depends(get_db)):
     return controller.create(db=db, request=request)
 
+@router.get("/sorted-by-date", response_model=list[schema.Order])
+def read_all_sorted_by_date(
+    date: datetime | None = Query(
+        None,
+        title="Date",
+        description="Filter orders by this date (YYYY-MM-DD)",
+        example="2024-11-06",
+    ),
+    db: Session = Depends(get_db),
+):
+    return controller.read_all_sorted_by_date(db, date)
 
 @router.get("/", response_model=list[schema.Order])
 def read_all(db: Session = Depends(get_db)):
@@ -33,3 +46,4 @@ def update(item_id: int, request: schema.OrderUpdate, db: Session = Depends(get_
 @router.delete("/{item_id}")
 def delete(item_id: int, db: Session = Depends(get_db)):
     return controller.delete(db=db, item_id=item_id)
+

--- a/api/schemas/orders.py
+++ b/api/schemas/orders.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel
+from pydantic import BaseModel,Field
 from .order_details import OrderDetail
 
 
@@ -21,8 +21,12 @@ class OrderUpdate(BaseModel):
 
 class Order(OrderBase):
     id: int
-    order_date: Optional[datetime] = None
+    order_date: str = Field(..., alias="order_date", description="Formatted order date")
     order_details: list[OrderDetail] = None
 
+    @staticmethod
+    def format_datetime(value: datetime) -> str:
+        """Format datetime to be a user friendly string."""
+        return value.strftime("%B %d, %Y, %I:%M %p")
     class ConfigDict:
         from_attributes = True


### PR DESCRIPTION
This pull request introduces a new feature to the app that allows users to filter and sort orders based on a provided date. Additionally, the order_date field in responses is now formatted in a user-friendly manner for better readability.

Changes Introduced:

New Endpoint:

Path: /orders/sorted-by-date
Method: GET
Functionality:
Returns all orders sorted by order_date in descending order.
Accepts an optional query parameter date (formatted as YYYY-MM-DD) to filter orders for a specific date.
Schema Updates:

Added user-friendly formatting for the order_date field in the response, e.g., November 6, 2024, 3:43 PM.
Controller Updates:

Added logic to filter orders based on the provided date.
Orders are sorted in descending order of order_date.
Tests:

Added/Updated tests to cover:
Orders returned without a date filter.
Orders filtered by a specific date.
Correct ordering and filtering logic.
