### PR TITLE
Feat: order status

### DIFF
--- a/api/models/orders.py
+++ b/api/models/orders.py
@@ -11,4 +11,5 @@ class Order(Base):
     customer_name = Column(String(100))
     order_date = Column(DATETIME, nullable=False, server_default=str(datetime.now()))
     description = Column(String(300))
+    status = Column(String(50), nullable=False, default="pending")
     order_details = relationship("OrderDetail", back_populates="order")

--- a/api/models/recipes.py
+++ b/api/models/recipes.py
@@ -11,6 +11,6 @@ class Recipe(Base):
     sandwich_id = Column(Integer, ForeignKey("sandwiches.id"))
     resource_id = Column(Integer, ForeignKey("resources.id"))
     amount = Column(Integer, index=True, nullable=False, server_default='0.0')
-
+    time_to_make = Column(Integer, nullable=False, server_default="0")
     sandwich = relationship("Sandwich", back_populates="recipes")
     resource = relationship("Resource", back_populates="recipes")

--- a/api/schemas/orders.py
+++ b/api/schemas/orders.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from typing import Optional
-from pydantic import BaseModel,Field
+from pydantic import BaseModel,Field, field_validator
 from .order_details import OrderDetail
 
 
@@ -8,7 +8,7 @@ from .order_details import OrderDetail
 class OrderBase(BaseModel):
     customer_name: str
     description: Optional[str] = None
-
+    status: str = "pending"
 
 class OrderCreate(OrderBase):
     pass
@@ -17,6 +17,7 @@ class OrderCreate(OrderBase):
 class OrderUpdate(BaseModel):
     customer_name: Optional[str] = None
     description: Optional[str] = None
+    status: Optional[str] = None
 
 
 class Order(OrderBase):
@@ -24,9 +25,12 @@ class Order(OrderBase):
     order_date: str = Field(..., alias="order_date", description="Formatted order date")
     order_details: list[OrderDetail] = None
 
-    @staticmethod
-    def format_datetime(value: datetime) -> str:
-        """Format datetime to be a user friendly string."""
-        return value.strftime("%B %d, %Y, %I:%M %p")
-    class ConfigDict:
+    @field_validator("order_date", mode="before")
+    def format_order_date(cls, value):
+        """Format the order_date field to a string."""
+        if isinstance(value, datetime):
+            return value.strftime("%Y-%m-%d %H:%M:%S")
+        return value
+
+    class Config:
         from_attributes = True

--- a/api/schemas/recipes.py
+++ b/api/schemas/recipes.py
@@ -7,6 +7,7 @@ from .sandwiches import Sandwich
 
 class RecipeBase(BaseModel):
     amount: int
+    time_to_make: int
 
 
 class RecipeCreate(RecipeBase):

--- a/api/tests/test_orders.py
+++ b/api/tests/test_orders.py
@@ -1,7 +1,7 @@
 from fastapi.testclient import TestClient
-from sqlalchemy.exc import SQLAlchemyError
 from unittest.mock import Mock
 import pytest
+from sqlalchemy.exc import SQLAlchemyError
 from ..main import app
 from ..controllers import orders as controller
 from ..models import orders as model
@@ -20,7 +20,8 @@ def test_create_order(db_session):
     # Mock data for an order
     order_data = {
         "customer_name": "John Doe",
-        "description": "Test order"
+        "description": "Test order",
+        "status": "pending"
     }
     request_data = model.Order(**order_data)
 
@@ -29,20 +30,25 @@ def test_create_order(db_session):
     db_session.commit = Mock()
     db_session.refresh = Mock()
 
+    def mock_refresh(order):
+        order.status = order_data["status"]
+
+    db_session.refresh.side_effect = mock_refresh
+
     # Call the create function
     created_order = controller.create(db_session, request_data)
 
     # Assertions
     assert created_order.customer_name == order_data["customer_name"]
     assert created_order.description == order_data["description"]
+    assert created_order.status == order_data["status"]
 
 
 def test_read_all_orders(db_session):
     # Mock a response list from the database
     db_session.query.return_value.all.return_value = [
-        model.Order(id=1, customer_name="John Doe", description="Test order"),
-        model.Order(id=2, customer_name="Jane Doe",
-                    description="Another test order")
+        model.Order(id=1, customer_name="John Doe", description="Test order", status="pending"),
+        model.Order(id=2, customer_name="Jane Doe", description="Another test order", status="ready")
     ]
 
     # Call the read_all function
@@ -51,13 +57,16 @@ def test_read_all_orders(db_session):
     # Assertions
     assert len(results) == 2
     assert results[0].customer_name == "John Doe"
+    assert results[0].status == "pending"
     assert results[1].customer_name == "Jane Doe"
+    assert results[1].status == "ready"
 
 
 def test_read_one_order(db_session):
     # Mock a single order
     db_session.query.return_value.filter.return_value.first.return_value = model.Order(
-        id=1, customer_name="John Doe", description="Test order")
+        id=1, customer_name="John Doe", description="Test order", status="preparing"
+    )
 
     # Call the read_one function
     result = controller.read_one(db_session, 1)
@@ -65,16 +74,18 @@ def test_read_one_order(db_session):
     # Assertions
     assert result is not None
     assert result.customer_name == "John Doe"
+    assert result.status == "preparing"
 
 
 def test_update_order(db_session):
     # Mock an existing order to update
     existing_order = model.Order(
-        id=1, customer_name="John Doe", description="Test order")
+        id=1, customer_name="John Doe", description="Test order", status="pending"
+    )
     db_session.query.return_value.filter.return_value.first.return_value = existing_order
 
     # Mock update data
-    update_data = {"description": "Updated order description"}
+    update_data = {"description": "Updated order description", "status": "ready"}
     request_data = Mock()
     request_data.dict.return_value = update_data
 
@@ -86,15 +97,18 @@ def test_update_order(db_session):
 
     # Manually adjust the mock to simulate the update
     existing_order.description = update_data["description"]
+    existing_order.status = update_data["status"]
 
     # Assertions
     assert updated_order.description == "Updated order description"
+    assert updated_order.status == "ready"
 
 
 def test_delete_order(db_session):
     # Mock an existing order to delete
     db_session.query.return_value.filter.return_value.first.return_value = model.Order(
-        id=1, customer_name="John Doe", description="Test order")
+        id=1, customer_name="John Doe", description="Test order", status="pending"
+    )
 
     # Call the delete function
     response = controller.delete(db_session, 1)
@@ -104,8 +118,8 @@ def test_delete_order(db_session):
 def test_read_all_sorted_by_date(db_session):
     # Mock data for orders
     orders_data = [
-        model.Order(id=1, customer_name="John Doe", description="Test order", order_date=datetime(2024, 11, 17, 10, 30)),
-        model.Order(id=2, customer_name="Jane Doe", description="Another test order", order_date=datetime(2024, 11, 16, 15, 45)),
+        model.Order(id=1, customer_name="John Doe", description="Test order", status="pending", order_date=datetime(2024, 11, 17, 10, 30)),
+        model.Order(id=2, customer_name="Jane Doe", description="Another test order", status="ready", order_date=datetime(2024, 11, 16, 15, 45)),
     ]
 
     db_session.query.return_value.order_by.return_value.all.return_value = orders_data
@@ -113,8 +127,11 @@ def test_read_all_sorted_by_date(db_session):
     results = controller.read_all_sorted_by_date(db_session)
     assert len(results) == 2
     assert results[0].order_date > results[1].order_date
+    assert results[0].status == "pending"
+    assert results[1].status == "ready"
 
     db_session.query.return_value.filter.return_value.order_by.return_value.all.return_value = [orders_data[1]]
     results_filtered = controller.read_all_sorted_by_date(db_session, datetime(2024, 11, 16))
     assert len(results_filtered) == 1
     assert results_filtered[0].customer_name == "Jane Doe"
+    assert results_filtered[0].status == "ready"

--- a/api/tests/test_recipes.py
+++ b/api/tests/test_recipes.py
@@ -20,7 +20,8 @@ def test_create_recipe(db_session):
     recipe_data = {
         "sandwich_id": 1,
         "resource_id": 2,
-        "amount": 3
+        "amount": 3,
+        "time_to_make": 10
     }
     request_data = model.Recipe(**recipe_data)
 
@@ -29,6 +30,11 @@ def test_create_recipe(db_session):
     db_session.commit = Mock()
     db_session.refresh = Mock()
 
+    def mock_refresh(recipe):
+        recipe.time_to_make = recipe_data["time_to_make"]
+
+    db_session.refresh.side_effect = mock_refresh
+
     # Call the create function
     created_recipe = controller.create(db_session, request_data)
 
@@ -36,13 +42,14 @@ def test_create_recipe(db_session):
     assert created_recipe.sandwich_id == recipe_data["sandwich_id"]
     assert created_recipe.resource_id == recipe_data["resource_id"]
     assert created_recipe.amount == recipe_data["amount"]
+    assert created_recipe.time_to_make == recipe_data["time_to_make"]
 
 
 def test_read_all_recipes(db_session):
     # Mock a response list from the database
     db_session.query.return_value.all.return_value = [
-        model.Recipe(id=1, sandwich_id=1, resource_id=2, amount=3),
-        model.Recipe(id=2, sandwich_id=2, resource_id=3, amount=4)
+        model.Recipe(id=1, sandwich_id=1, resource_id=2, amount=3, time_to_make=10),
+        model.Recipe(id=2, sandwich_id=2, resource_id=3, amount=4, time_to_make=15)
     ]
 
     # Call the read_all function
@@ -51,13 +58,15 @@ def test_read_all_recipes(db_session):
     # Assertions
     assert len(results) == 2
     assert results[0].sandwich_id == 1
+    assert results[0].time_to_make == 10
     assert results[1].sandwich_id == 2
+    assert results[1].time_to_make == 15
 
 
 def test_read_one_recipe(db_session):
     # Mock a single recipe
     db_session.query.return_value.filter.return_value.first.return_value = model.Recipe(
-        id=1, sandwich_id=1, resource_id=2, amount=3)
+        id=1, sandwich_id=1, resource_id=2, amount=3, time_to_make=10)
 
     # Call the read_one function
     result = controller.read_one(db_session, 1)
@@ -65,16 +74,17 @@ def test_read_one_recipe(db_session):
     # Assertions
     assert result is not None
     assert result.sandwich_id == 1
+    assert result.time_to_make == 10
 
 
 def test_update_recipe(db_session):
     # Mock an existing recipe to update
     existing_recipe = model.Recipe(
-        id=1, sandwich_id=1, resource_id=2, amount=3)
+        id=1, sandwich_id=1, resource_id=2, amount=3, time_to_make=10)
     db_session.query.return_value.filter.return_value.first.return_value = existing_recipe
 
     # Mock update data
-    update_data = {"amount": 5}
+    update_data = {"amount": 5, "time_to_make": 20}
     request_data = Mock()
     request_data.dict.return_value = update_data
 
@@ -86,20 +96,20 @@ def test_update_recipe(db_session):
 
     # Manually adjust the mock to simulate the update
     existing_recipe.amount = update_data["amount"]
+    existing_recipe.time_to_make = update_data["time_to_make"]
 
     # Assertions
     assert updated_recipe.amount == 5
+    assert updated_recipe.time_to_make == 20
 
 
 def test_delete_recipe(db_session):
     # Mock an existing recipe to delete
     db_session.query.return_value.filter.return_value.first.return_value = model.Recipe(
-        id=1, sandwich_id=1, resource_id=2, amount=3)
+        id=1, sandwich_id=1, resource_id=2, amount=3, time_to_make=10)
 
     # Call the delete function
     response = controller.delete(db_session, 1)
 
     # Assertions
     assert response.status_code == 204
-
-


### PR DESCRIPTION
This PR adds support for the status field in the orders tests and ensures proper handling of default values during test execution. A mock refresh method was implemented in test_create_order to simulate the behavior of the database, setting the status field to its default value ("pending"). All other test cases were verified for consistency and include assertions for the status field.

Key Changes:

Added mock_refresh to test_create_order for populating status.
Verified status handling in all relevant test cases.
Ensured tests for read, update, and delete operations include status.
All tests now pass successfully.